### PR TITLE
Added in virus scanning with clamscan

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from shutil import rmtree
 from waitress import serve
 from flask import Flask, url_for, flash, Markup, render_template, request, redirect, abort, send_from_directory
 from werkzeug import secure_filename
+from subprocess import call
 
 # Load config file
 config = {}
@@ -73,7 +74,10 @@ def checkFileHash(fhash): # returns: true for clean and false for dirty.
     return not any(d['hash'] == fhash for d in banlist)
 
 def scanForViruses(fpath): # returns: true for clean file and false for virus
-    return True # Not implemented yet
+    # Uses clamd, you must have it installed for this to work.
+    call(["clamscan", "--infected", "--remove", fpath])
+    # If the file was removed, return False(There is a virus), otherwise True
+    return os.path.exists(fpath)
 
 def handleUpload(f, js=True, api=False):
     """ Handles the main file upload behavior. """


### PR DESCRIPTION
Tested on the eicar file, which was succesfully added to the banned file list. Can you think of some way to have the config file be automatically reloaded? That would make stuff less painless if a file had to be manually added into the csv. 
